### PR TITLE
Correct Facebook Developers URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the official ngCordova repo.</li></ul>
 
 This repo uses wizcorps facebook login plugin for facebook auth.
 
-<h5>Step 1: Goto https://www.developers.facebook.com </h5> 
+<h5>Step 1: Goto https://developers.facebook.com </h5> 
 
 ![Alt text](./screenshots/facebook/1.png?raw=true "Goto developers.facebook.com")
 


### PR DESCRIPTION
Remove unnecessary 'www.' from the URL
